### PR TITLE
fix(#56): various bug fixes and improvements for final integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-# Run CI server with uvicorn
+# Run CI server with uvicorn (with hot reload)
 uvicorn:
 	uvicorn src.main:app --host 0.0.0.0 --port 8001 --reload-exclude ./temp/** --reload
+
+# Run CI server with uvicorn
+uvicorn_prod:
+	uvicorn src.main:app --host 0.0.0.0 --port 8001
 
 # Run unittests
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Run CI server with uvicorn (with hot reload)
-uvicorn:
+uvicorn_dev:
 	uvicorn src.main:app --host 0.0.0.0 --port 8001 --reload-exclude ./temp/** --reload
 
 # Run CI server with uvicorn
-uvicorn_prod:
+uvicorn:
 	uvicorn src.main:app --host 0.0.0.0 --port 8001
 
 # Run unittests
@@ -31,6 +31,7 @@ help:
 	@echo "Makefile Help:"
 	@echo ""
 	@echo "Available targets:"
+	@echo "  uvicorn_dev    - Run CI server with uvicorn with hot reload (hosted at 0.0.0.0:8001)"
 	@echo "  uvicorn        - Run CI server with uvicorn (hosted at 0.0.0.0:8001)"
 	@echo "  test           - Run unit tests with unittest"
 	@echo "  docker_dev     - Start Docker development environment with hot reload"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make docker_man
 ```
 ```bash
 # alternatively, start development locally
-make uvicorn
+make uvicorn_dev
 # you can only run unit tests locally
 make test
 ```

--- a/src/modules/actions.py
+++ b/src/modules/actions.py
@@ -112,7 +112,7 @@ def run_tests(target_folder: str) -> tuple[bool, str]:
     if not check_if_folder_exists(target_folder):
         raise ValueError(f"The provided path {target_folder} is not a valid directory.")
 
-    test_command = "python -m unittest"
+    test_command = ". .venv/bin/activate && python -m unittest"
     result = subprocess.run(
         test_command, capture_output=True, shell=True, cwd=target_folder
     )

--- a/src/modules/actions.py
+++ b/src/modules/actions.py
@@ -22,7 +22,9 @@ def clone_repo(url: str, destination: str) -> str:
         err.add_note(ret.stderr.decode())
         raise err
 
-    return ret.stdout.decode()
+    # Git commands outputs information message on stderr
+    # see https://stackoverflow.com/questions/57016157/how-to-stop-git-from-writing-non-errors-to-stderr
+    return ret.stderr.decode()
 
 
 def checkout_ref(target_folder: str, ref: str) -> str:
@@ -44,7 +46,9 @@ def checkout_ref(target_folder: str, ref: str) -> str:
         err.add_note(ret.stderr.decode())
         raise err
 
-    return ret.stdout.decode()
+    # Git commands outputs information message on stderr
+    # see https://stackoverflow.com/questions/57016157/how-to-stop-git-from-writing-non-errors-to-stderr
+    return ret.stderr.decode()
 
 
 def setup_dependencies(target_folder: str) -> str:

--- a/src/modules/actions.py
+++ b/src/modules/actions.py
@@ -112,7 +112,14 @@ def run_tests(target_folder: str) -> tuple[bool, str]:
     if not check_if_folder_exists(target_folder):
         raise ValueError(f"The provided path {target_folder} is not a valid directory.")
 
-    test_command = ". .venv/bin/activate && python -m unittest"
+    # .venv might not exist if the setup_dependencies function was not called
+    test_command = """
+    if test -d .venv; then
+        . .venv/bin/activate
+    fi
+    python -m unittest
+    """
+
     result = subprocess.run(
         test_command, capture_output=True, shell=True, cwd=target_folder
     )

--- a/src/modules/notifications.py
+++ b/src/modules/notifications.py
@@ -32,8 +32,9 @@ def add_commit_status(
     }
     payload = {
         "state": state.value,
-        "description": f"Custom CI/CD job {id} is {state.value}. URL for CI job log for more details: https://secretly-native-ant.ngrok-free.app/logs/{id}",
+        "description": "Custom CI/CD job was ran. Job details and logs can be viewed in the URL.",
         "context": "custom-ci/lint-and-test",
+        "target_url": f"https://secretly-native-ant.ngrok-free.app/logs/{id}",
     }
     response = requests.post(url, headers=headers, json=payload)
 

--- a/src/modules/notifications.py
+++ b/src/modules/notifications.py
@@ -2,6 +2,10 @@ from src.modules.types import Status
 from fastapi import HTTPException
 import requests
 import os
+from dotenv import load_dotenv
+
+# normally this is loaded in main.py, but we need it here for the tests
+load_dotenv()
 
 
 def add_commit_status(

--- a/src/modules/notifications.py
+++ b/src/modules/notifications.py
@@ -43,9 +43,11 @@ def add_commit_status(
     response = requests.post(url, headers=headers, json=payload)
 
     if response.status_code != 201:
-        raise HTTPException(
+        err = HTTPException(
             status_code=response.status_code, detail="Failed to update commit status."
         )
+        err.add_note(response.json())
+        raise err
 
 
 def get_commit_status(owner: str, repo: str, ref: str) -> Status:
@@ -71,9 +73,11 @@ def get_commit_status(owner: str, repo: str, ref: str) -> Status:
     response = requests.get(url, headers=headers)
 
     if response.status_code != 200:
-        raise HTTPException(
+        err = HTTPException(
             status_code=response.status_code, detail="Failed to get commit status."
         )
+        err.add_note(response.json())
+        raise err
 
     status = response.json()["state"]
 


### PR DESCRIPTION
Closes #56.

This PR fixes various issues:
- the logs returned by `clone_repo` and `checkout_ref` were always empty due to a misconfiguration
- support external dependencies of target repo by using venv in `run_tests`
- HTTP 422 errors when running `add_commit_status`
- improve error logging for the notification service
- ensure that unit tests for notifications do not fail because of missing dotenv imports
- update `uvicorn` command in makefile for mitigating potential reloads due to `temp` folder