### PR TITLE
docs(#49): add documentation for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Note: In case you are unsure about the available commands you can run `make help
 
 ### Static Syntax Check
 
+The static syntax check is done by executing the `run_linter_check` function which is called in the CI servers processing pipeline in the main function. The `run_linter_check` function executes a check with flake8 on the respective target folder with flags to only look for E9,F63,F82,F7 errors, which we deemed as indicating of potential syntax errors.
+
+Unit testing is performed by running the linting check on a series of fixture folders in the tests folder. Some folders contain code that should pass the check without triggering any errors and others contain code that are supposed to trigger the various errors we are checking for. The output of flake8 is then checked to make sure it contains certain keywords that indicate right behaviour.
+
 ### Testing
 
 ### Notification


### PR DESCRIPTION
This adds documentation on compilation and how its unittesting was implemented to the README thus closing issue #49.